### PR TITLE
fix: handle missing AI responses in policy vulnerability checks

### DIFF
--- a/core/policy.py
+++ b/core/policy.py
@@ -41,6 +41,8 @@ class Policy:
 
     def is_vulnerable(self):
         vulnerable = 'CHECK CSV'
+        if self.ai_response is None:
+            return vulnerable
         
         if 'Yes,' in self.ai_response:
             vulnerable = 'VULNERABLE'

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -77,13 +77,7 @@ class TestPolicy:
     def test_is_vulnerable_no_response(self):
         """Test vulnerability detection with no AI response"""
         policy = Policy()
-        # When ai_response is None, the method will raise TypeError
-        # This test documents the actual behavior
-        try:
-            result = policy.is_vulnerable()
-            assert False, "Should have raised TypeError"
-        except TypeError:
-            pass  # Expected behavior
+        assert policy.is_vulnerable() == "CHECK CSV"
 
     def test_is_vulnerable_empty_response(self):
         """Test vulnerability detection with empty response"""


### PR DESCRIPTION
## Summary
- Keep `Policy.is_vulnerable()` from raising `TypeError` when `ai_response` is still `None`.
- Preserve the existing fallback classification by returning `CHECK CSV` for policies that have not received AI analysis yet.
- Update the existing no-response regression test to assert the graceful fallback instead of documenting the crash.

Closes #10

## Tests
- RED before fix: `python3 -m pytest tests/test_policy.py -q -o addopts=''` failed with `TypeError: argument of type 'NoneType' is not iterable` in `Policy.is_vulnerable()`.
- `python3 -m pytest tests/test_policy.py -q -o addopts=''`
- `python3 -m py_compile core/policy.py tests/test_policy.py`

## Notes
- `python3 -m pytest tests -q -o addopts=''` was also attempted, but collection currently requires the optional `openai` dependency (`ModuleNotFoundError: No module named 'openai'`) in this reconstructed workspace.
